### PR TITLE
Add atlas scale and maxSize

### DIFF
--- a/imgproc/texturing.cpp
+++ b/imgproc/texturing.cpp
@@ -165,13 +165,17 @@ math::Size2 pack(Patch::list &patches, float scale,
         }
 
         // inflate area
-        if (packSize.width <= packSize.height) {
+        if (packSize.width <= packSize.height
+            && (!maxAllowed || packSize.width < maxAllowed->width))
+        {
             packSize.width *= scale;
 
             if (maxAllowed) {
                 packSize.width = std::min(packSize.width, maxAllowed->width);
             }
-        } else {
+        }
+        else
+        {
             packSize.height *= scale;
 
             if (maxAllowed) {

--- a/imgproc/texturing.cpp
+++ b/imgproc/texturing.cpp
@@ -141,7 +141,7 @@ bool Node::allocateSpace(Patch &patch, const math::Size2 &patchSize
 
 } // namespace
 
-math::Size2 pack(Patch::list &patches, float scale,
+math::Size2 pack(Patch::list &patches, float inflateFactor,
                  boost::optional<math::Size2i> maxAllowed)
 {
     LOG(debug) << "Packing " << patches.size() << " rectangles.";
@@ -168,7 +168,7 @@ math::Size2 pack(Patch::list &patches, float scale,
         if (packSize.width <= packSize.height
             && (!maxAllowed || packSize.width < maxAllowed->width))
         {
-            packSize.width *= scale;
+            packSize.width *= inflateFactor;
 
             if (maxAllowed) {
                 packSize.width = std::min(packSize.width, maxAllowed->width);
@@ -176,7 +176,7 @@ math::Size2 pack(Patch::list &patches, float scale,
         }
         else
         {
-            packSize.height *= scale;
+            packSize.height *= inflateFactor;
 
             if (maxAllowed) {
                 packSize.height = std::min(packSize.height, maxAllowed->height);

--- a/imgproc/texturing.cpp
+++ b/imgproc/texturing.cpp
@@ -141,7 +141,8 @@ bool Node::allocateSpace(Patch &patch, const math::Size2 &patchSize
 
 } // namespace
 
-math::Size2 pack(Patch::list &patches)
+math::Size2 pack(Patch::list &patches, float scale,
+                 boost::optional<math::Size2i> maxAllowed)
 {
     LOG(debug) << "Packing " << patches.size() << " rectangles.";
 
@@ -157,11 +158,25 @@ math::Size2 pack(Patch::list &patches)
 
     auto inflate([&]()
     {
+        if (maxAllowed && packSize == *maxAllowed) {
+            LOGTHROW(err2, AreaTooLarge)
+                << "Won't fit: maximum (allowed) size reached: " << maxAllowed
+                << ".";
+        }
+
         // inflate area
         if (packSize.width <= packSize.height) {
-            packSize.width *= 2;
+            packSize.width *= scale;
+
+            if (maxAllowed) {
+                packSize.width = std::min(packSize.width, maxAllowed->width);
+            }
         } else {
-            packSize.height *= 2;
+            packSize.height *= scale;
+
+            if (maxAllowed) {
+                packSize.height = std::min(packSize.height, maxAllowed->height);
+            }
         }
 
         // and check

--- a/imgproc/texturing.hpp
+++ b/imgproc/texturing.hpp
@@ -167,23 +167,35 @@ private:
 
 /** Packs texture patches.
  *  Returns size of resulting texture.
+ *
+ *  @param inflateFactor Specifies how much the atlas grows (in 1 dimension)
+ *                       after every unsuccessful packing attempt.
+ *  @param maxAllowed The maximum atlas size acceptable by the caller.
  */
-math::Size2 pack(Patch::list &patches, float scale = 2.f,
+math::Size2 pack(Patch::list &patches, float inflateFactor = 2.f,
                  boost::optional<math::Size2i> maxAllowed = boost::none);
 
 /** Packs texture patches.
  *  Returns size of resulting texture.
  *
  * Const vector interface.
+ *
+ *  @param inflateFactor Specifies how much the atlas grows (in 1 dimension)
+ *                       after every unsuccessful packing attempt.
+ *  @param maxAllowed The maximum atlas size acceptable by the caller.
  */
-math::Size2 pack(const Patch::list &patches, float scale = 2.f,
+math::Size2 pack(const Patch::list &patches, float inflateFactor = 2.f,
                  boost::optional<math::Size2i> maxAllowed = boost::none);
 
 /** Generate container.
  *  Function Patch* asPatch(*iterator) must exist.
+ *
+ *  @param inflateFactor Specifies how much the atlas grows (in 1 dimension)
+ *                       after every unsuccessful packing attempt.
+ *  @param maxAllowed The maximum atlas size acceptable by the caller.
  */
 template <typename Iterator>
-math::Size2 pack(Iterator begin, Iterator end, float scale = 2.f,
+math::Size2 pack(Iterator begin, Iterator end, float inflateFactor = 2.f,
                  boost::optional<math::Size2i> maxAllowed = boost::none);
 
 /** Default implementaion of asPatch for, well, patch itself.
@@ -291,22 +303,22 @@ template <typename T> void UvPatch::update(const math::Point2_<T> &point)
     update(point(0), point(1));
 }
 
-inline math::Size2 pack(const Patch::list &patches, float scale,
+inline math::Size2 pack(const Patch::list &patches, float inflateFactor,
                         boost::optional<math::Size2i> maxAllowed)
 {
     auto copy(patches);
-    return pack(copy, scale, maxAllowed);
+    return pack(copy, inflateFactor, maxAllowed);
 }
 
 template <typename Iterator>
-math::Size2 pack(Iterator begin, Iterator end, float scale,
+math::Size2 pack(Iterator begin, Iterator end, float inflateFactor,
                  boost::optional<math::Size2i> maxAllowed)
 {
     Patch::list patches;
     for (; begin != end; ++begin) {
         patches.push_back(asPatch(*begin));
     }
-    return pack(patches, scale, maxAllowed);
+    return pack(patches, inflateFactor, maxAllowed);
 }
 
 inline Patch* asPatch(Patch &patch) { return &patch; }

--- a/imgproc/texturing.hpp
+++ b/imgproc/texturing.hpp
@@ -28,6 +28,8 @@
 
 #include <vector>
 
+#include <boost/optional/optional_io.hpp>
+
 #include "math/geometry_core.hpp"
 
 namespace imgproc { namespace tx {
@@ -166,20 +168,23 @@ private:
 /** Packs texture patches.
  *  Returns size of resulting texture.
  */
-math::Size2 pack(Patch::list &patches);
+math::Size2 pack(Patch::list &patches, float scale = 2.f,
+                 boost::optional<math::Size2i> maxAllowed = boost::none);
 
 /** Packs texture patches.
  *  Returns size of resulting texture.
  *
  * Const vector interface.
  */
-math::Size2 pack(const Patch::list &patches);
+math::Size2 pack(const Patch::list &patches, float scale = 2.f,
+                 boost::optional<math::Size2i> maxAllowed = boost::none);
 
 /** Generate container.
  *  Function Patch* asPatch(*iterator) must exist.
  */
 template <typename Iterator>
-math::Size2 pack(Iterator begin, Iterator end);
+math::Size2 pack(Iterator begin, Iterator end, float scale = 2.f,
+                 boost::optional<math::Size2i> maxAllowed = boost::none);
 
 /** Default implementaion of asPatch for, well, patch itself.
  */
@@ -286,19 +291,22 @@ template <typename T> void UvPatch::update(const math::Point2_<T> &point)
     update(point(0), point(1));
 }
 
-inline math::Size2 pack(const Patch::list &patches) {
+inline math::Size2 pack(const Patch::list &patches, float scale,
+                        boost::optional<math::Size2i> maxAllowed)
+{
     auto copy(patches);
-    return pack(copy);
+    return pack(copy, scale, maxAllowed);
 }
 
 template <typename Iterator>
-math::Size2 pack(Iterator begin, Iterator end)
+math::Size2 pack(Iterator begin, Iterator end, float scale,
+                 boost::optional<math::Size2i> maxAllowed)
 {
     Patch::list patches;
     for (; begin != end; ++begin) {
         patches.push_back(asPatch(*begin));
     }
-    return pack(patches);
+    return pack(patches, scale, maxAllowed);
 }
 
 inline Patch* asPatch(Patch &patch) { return &patch; }


### PR DESCRIPTION
- Adds option to specify atlas scale factor (default = 2.0)
- Optional maxAtlasSize which limits the size of the atlas that's acceptable by the caller (e.g. if we wanna save the resulting atlas as JPEG -> 65500x65500 (libjpeg limit)).